### PR TITLE
Fix indentation in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,56 +126,56 @@ To use the `microsoft.outlook.mail` connector in your Ballerina application, upd
 
 Import the `microsoft.outlook.mail` module.
 
-   ```ballerina
-   import ballerinax/microsoft.outlook.mail;
-   ```
+```ballerina
+import ballerinax/microsoft.outlook.mail;
+```
 
 ### Step 2: Instantiate a new connector
 
 1. Create a `Config.toml` file and configure the credentials obtained above:
 
-   ```toml
-   clientId = "<CLIENT_ID>"
-   clientSecret = "<CLIENT_SECRET>"
-   refreshToken = "<REFRESH_TOKEN>"
-   refreshUrl = "<REFRESH_URL>"
-   ```
+```toml
+clientId = "<CLIENT_ID>"
+clientSecret = "<CLIENT_SECRET>"
+refreshToken = "<REFRESH_TOKEN>"
+refreshUrl = "<REFRESH_URL>"
+```
 
 2. Instantiate a `mail:ConnectionConfig` with the obtained credentials and initialize the connector with it.
 
-   ```ballerina
-   configurable string clientId = ?;
-   configurable string clientSecret = ?;
-   configurable string refreshToken = ?;
-   configurable string refreshUrl = ?;
+```ballerina
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable string refreshToken = ?;
+configurable string refreshUrl = ?;
 
-   final mail:Client outlookClient = check new ({
-      auth: {
-         clientId,
-         clientSecret,
-         refreshToken,
-         refreshUrl
-      }
-   });
-   ```
+final mail:Client outlookClient = check new ({
+   auth: {
+      clientId,
+      clientSecret,
+      refreshToken,
+      refreshUrl
+   }
+});
+```
 
 ### Step 3: Invoke the connector operation
 
 Now, utilize the available connector operations. A sample use case is shown below.
 
-   ```ballerina
-   // List the most recent messages in the mailbox
-   public function main() returns error? {
-      mail:MicrosoftGraphMessageCollectionResponse response = check outlookClient->listMessages(
-         dollarTop = 5,
-         dollarSelect = ["id", "subject", "from", "receivedDateTime", "isRead"]
-      );
-      mail:MicrosoftGraphMessage[] messages = response.value ?: [];
-      foreach mail:MicrosoftGraphMessage message in messages {
-         io:println("Subject: ", message?.subject, " | Read: ", message?.isRead);
-      }
+```ballerina
+// List the most recent messages in the mailbox
+public function main() returns error? {
+   mail:MicrosoftGraphMessageCollectionResponse response = check outlookClient->listMessages(
+      dollarTop = 5,
+      dollarSelect = ["id", "subject", "from", "receivedDateTime", "isRead"]
+   );
+   mail:MicrosoftGraphMessage[] messages = response.value ?: [];
+   foreach mail:MicrosoftGraphMessage message in messages {
+      io:println("Subject: ", message?.subject, " | Read: ", message?.isRead);
    }
-   ```
+}
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ To use the `microsoft.outlook.mail` connector in your Ballerina application, upd
 
 Import the `microsoft.outlook.mail` module.
 
-```ballerina
-import ballerinax/microsoft.outlook.mail;
-```
+   ```ballerina
+   import ballerinax/microsoft.outlook.mail;
+   ```
 
 ### Step 2: Instantiate a new connector
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -124,56 +124,56 @@ To use the `microsoft.outlook.mail` connector in your Ballerina application, upd
 
 Import the `microsoft.outlook.mail` module.
 
-   ```ballerina
-   import ballerinax/microsoft.outlook.mail;
-   ```
+```ballerina
+import ballerinax/microsoft.outlook.mail;
+```
 
 ### Step 2: Instantiate a new connector
 
 1. Create a `Config.toml` file and configure the credentials obtained above:
 
-   ```toml
-   clientId = "<CLIENT_ID>"
-   clientSecret = "<CLIENT_SECRET>"
-   refreshToken = "<REFRESH_TOKEN>"
-   refreshUrl = "<REFRESH_URL>"
-   ```
+```toml
+clientId = "<CLIENT_ID>"
+clientSecret = "<CLIENT_SECRET>"
+refreshToken = "<REFRESH_TOKEN>"
+refreshUrl = "<REFRESH_URL>"
+```
 
 2. Instantiate a `mail:ConnectionConfig` with the obtained credentials and initialize the connector with it.
 
-   ```ballerina
-   configurable string clientId = ?;
-   configurable string clientSecret = ?;
-   configurable string refreshToken = ?;
-   configurable string refreshUrl = ?;
+```ballerina
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable string refreshToken = ?;
+configurable string refreshUrl = ?;
 
-   final mail:Client outlookClient = check new ({
-      auth: {
-         clientId,
-         clientSecret,
-         refreshToken,
-         refreshUrl
-      }
-   });
-   ```
+final mail:Client outlookClient = check new ({
+   auth: {
+      clientId,
+      clientSecret,
+      refreshToken,
+      refreshUrl
+   }
+});
+```
 
 ### Step 3: Invoke the connector operation
 
 Now, utilize the available connector operations. A sample use case is shown below.
 
-   ```ballerina
-   // List the most recent messages in the mailbox
-   public function main() returns error? {
-      mail:MicrosoftGraphMessageCollectionResponse response = check outlookClient->listMessages(
-         dollarTop = 5,
-         dollarSelect = ["id", "subject", "from", "receivedDateTime", "isRead"]
-      );
-      mail:MicrosoftGraphMessage[] messages = response.value ?: [];
-      foreach mail:MicrosoftGraphMessage message in messages {
-         io:println("Subject: ", message?.subject, " | Read: ", message?.isRead);
-      }
+```ballerina
+// List the most recent messages in the mailbox
+public function main() returns error? {
+   mail:MicrosoftGraphMessageCollectionResponse response = check outlookClient->listMessages(
+      dollarTop = 5,
+      dollarSelect = ["id", "subject", "from", "receivedDateTime", "isRead"]
+   );
+   mail:MicrosoftGraphMessage[] messages = response.value ?: [];
+   foreach mail:MicrosoftGraphMessage message in messages {
+      io:println("Subject: ", message?.subject, " | Read: ", message?.isRead);
    }
-   ```
+}
+```
 
 ## Examples
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -124,9 +124,9 @@ To use the `microsoft.outlook.mail` connector in your Ballerina application, upd
 
 Import the `microsoft.outlook.mail` module.
 
-```ballerina
-import ballerinax/microsoft.outlook.mail;
-```
+   ```ballerina
+   import ballerinax/microsoft.outlook.mail;
+   ```
 
 ### Step 2: Instantiate a new connector
 


### PR DESCRIPTION
# Description
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the documentation in the Quickstart section of the README files to improve clarity and formatting consistency.

## Changes

- **Added configuration example**: Introduced a new `Config.toml` example demonstrating how to set up required connector configuration fields (`clientId`, `clientSecret`, `refreshToken`, `refreshUrl`)
- **Reformatted code snippets**: Updated the Ballerina code examples to display `configurable` connector configuration fields and their wiring into a `mail:Client` instance
- **Improved formatting**: Adjusted indentation and line formatting in the operation example (`listMessages`) to enhance readability while maintaining the same functionality

The changes are documentation-only with no modifications to the codebase or public APIs. The net change reflects code reformatting rather than new content additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-microsoft.outlook.mail/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->