### PR TITLE
Fix token endpoint path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Before using the connector, obtain a refresh token using the following OAuth2 au
    https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=<CLIENT_ID>&response_type=code&redirect_uri=<REDIRECT_URI>&scope=<SCOPE>&response_mode=query
    ```
 
-   Example values for `<SCOPE>`: `Mail.Read Mail.ReadWrite Mail.Send MailboxSettings.Read offline_access`
+   Example values for `<SCOPE>`: `Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access`
 
 2. Open the URL in a browser and sign in with your Microsoft account. Grant the requested permissions.
 
@@ -117,6 +117,8 @@ Before using the connector, obtain a refresh token using the following OAuth2 au
    ```
 
 5. Store the `refresh_token` securely for use in your application.
+
+6. Use `https://login.microsoftonline.com/common/oauth2/v2.0/token` as the `REFRESH_URL`.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Before using the connector, obtain a refresh token using the following OAuth2 au
 4. Exchange the authorization code for tokens by running the following `curl` command. Replace the placeholder values with your specific values. For `SCOPE` you can use this `Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access`
 
    ```bash
-    curl --location 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token' \
+    curl --location 'https://login.microsoftonline.com/common/oauth2/v2.0/token' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'grant_type=authorization_code' \
     --data-urlencode 'code=<CODE>' \

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -90,7 +90,7 @@ Before using the connector, obtain a refresh token using the following OAuth2 au
 4. Exchange the authorization code for tokens by running the following `curl` command. Replace the placeholder values with your specific values. For `SCOPE` you can use this `Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access`.
 
    ```bash
-    curl --location 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token' \
+    curl --location 'https://login.microsoftonline.com/common/oauth2/v2.0/token' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'grant_type=authorization_code' \
     --data-urlencode 'code=<CODE>' \
@@ -114,7 +114,7 @@ Before using the connector, obtain a refresh token using the following OAuth2 au
 
 5. Store the `refresh_token` securely for use in your application.
 
-6. Use `https://login.microsoftonline.com/consumers/oauth2/v2.0/token` as the `REFRESH_URL`.
+6. Use `https://login.microsoftonline.com/common/oauth2/v2.0/token` as the `REFRESH_URL`.
 
 ## Quickstart
 


### PR DESCRIPTION
# Description
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request updates the Microsoft Outlook Mail connector documentation to correct the OAuth2 token endpoint configuration. The changes update both the root-level README.md and ballerina/README.md files to use the Microsoft "common" tenant endpoint instead of the "consumers" endpoint for token operations.

Specifically, the OAuth2 token endpoint URL in the authentication setup instructions is updated from `https://login.microsoftonline.com/consumers/oauth2/v2.0/token` to `https://login.microsoftonline.com/common/oauth2/v2.0/token` in two locations:
- The curl command example for exchanging authorization codes
- The documented REFRESH_URL value for token refresh operations

These changes ensure users configure the correct Microsoft identity endpoint when integrating the connector with Microsoft Outlook Mail services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-microsoft.outlook.mail/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->