### PR TITLE
Add missing `contentBytes` field into `MicrosoftGraphAttachment` record

### DIFF
--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -696,6 +696,8 @@ public type MicrosoftGraphAttachment record {
     boolean isInline?;
     # The MIME type
     string? contentType?;
+    # The base64-encoded contents of the file attachment. Required only for file attachments
+    string? contentBytes?;
 };
 
 public type MicrosoftGraphUploadSession record {

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -2856,6 +2856,11 @@ components:
             type: string
             description: The MIME type
             nullable: true
+          contentBytes:
+            type: string
+            description: The base64-encoded contents of the file attachment. Required only for file attachments
+            nullable: true
+            format: base64url
         discriminator:
           propertyName: '@odata.type'
           mapping:


### PR DESCRIPTION
# Description
The `MicrosoftGraphAttachment` record is currently missing the `contentBytes` field defined in the Microsoft Graph API spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This pull request adds the missing `contentBytes` field to the `MicrosoftGraphAttachment` record, bringing the Ballerina module into alignment with the Microsoft Graph API specification.

## Changes
The implementation was updated in two locations:

**Type Definition (`ballerina/types.bal`)**
- Added an optional `contentBytes` field (type: `string?`) to the `MicrosoftGraphAttachment` record
- Included documentation indicating the field contains base64-encoded content for file attachments

**API Specification (`docs/spec/openapi.yaml`)**
- Updated the `MicrosoftGraphAttachment` schema to include the `contentBytes` property
- Defined as a base64url-encoded string with nullable support
- Documented as applicable for file attachment types

## Impact
These changes improve API specification compliance by incorporating all properties defined in the Microsoft Graph API, ensuring the Ballerina module provides complete support for attachment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->